### PR TITLE
Autoload ruby-electric-mode for ruby-mode

### DIFF
--- a/ruby-electric.el
+++ b/ruby-electric.el
@@ -198,6 +198,13 @@ strings. Note that you must have Font Lock enabled."
   (ruby-indent-line t)
   (end-of-line))
 
+;; Makes sure that ruby buffers are given the ruby-electric minor mode by default
+;;;###autoload
+(eval-after-load 'ruby-mode
+  '(add-hook 'ruby-mode-hook
+             (lambda ()
+               (ruby-electric-mode))))
+
 (provide 'ruby-electric)
 
 ;;; ruby-electric.el ends here


### PR DESCRIPTION
Makes sure that ruby buffers are given the ruby-electric minor mode by default
