### PR TITLE
Make ruby-electric.el compatible with package.el

### DIFF
--- a/ruby-electric.el
+++ b/ruby-electric.el
@@ -1,4 +1,4 @@
-;; ruby-electric.el --- electric editing commands for ruby files
+;;; ruby-electric.el --- electric editing commands for ruby files
 ;;
 ;; Copyright (C) 2005 by Dee Zsombor
 ;;


### PR DESCRIPTION
I was trying to build a package for MELPA and noticed that package.el couldn't install the file due to a missing file header error. Turns out the fix was rather simple :)
