### PR TITLE
Change ruby-backward-sexp to backward-word on ruby-electric-space

### DIFF
--- a/ruby-electric.el
+++ b/ruby-electric.el
@@ -120,7 +120,7 @@ strings. Note that you must have Font Lock enabled."
              (ruby-electric-single-keyword-in-line-re
               (concat "\\s-*" ruby-electric-keywords-re)))
         (save-excursion
-          (ruby-backward-sexp 1)
+          (backward-word 1)
           (or (looking-at ruby-electric-expandable-do-re)
               (and (looking-at ruby-electric-keywords-re)
                    (not (string= "do" (match-string 1)))


### PR DESCRIPTION
In this version of ruby-electrict.el, `ruby-electric-space` fails with emacs snapshot (v2.3.50.1)

The error message is the following:

```
smie-forward-sexp-command: Scan error: "Containing expression ends prematurely", 581, 581
```

I tracked down the error to be on the execution of `ruby-backward-sexp`.
I have changed `ruby-backward-sexp` to `backward-word` on ruby so that the behavior is normal again, although you do have expansions with symbols (:def, :do, etc.), which I personally think is not a major issue. 
